### PR TITLE
Give the kubevirt-operator cluster level permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,6 @@ rm-olm:
 ##############
 
 cr:
-	# Temporary Hack: Need to fix rbac
-	oc adm policy add-cluster-role-to-user -z kubevirt-operator cluster-admin
 	oc create -f deploy/cr.yaml
 
 ##############

--- a/kubevirt-operator-configmap.yaml
+++ b/kubevirt-operator-configmap.yaml
@@ -1269,8 +1269,6 @@ data:
               - apiGroups:
                 - rbac.authorization.k8s.io
                 resources:
-                - clusterrole
-                - clusterrolebindings
                 - role
                 - rolebindings
                 - serviceaccounts
@@ -1283,6 +1281,7 @@ data:
               - apiGroups:
                 - ""
                 resources:
+                - serviceaccounts
                 - pods
                 - services
                 - endpoints
@@ -1301,6 +1300,21 @@ data:
                 - statefulsets
                 verbs:
                 - '*'
+
+            clusterPermissions:
+            - serviceAccountName: kubevirt-operator
+              rules:
+              - apiGroups:
+                - rbac.authorization.k8s.io
+                resources:
+                - clusterrole
+                - clusterrolebinding
+                verbs:
+                - get
+                - create
+                - delete
+                - patch
+                - update
 
             deployments:
             - name: kubevirt-operator
@@ -1388,8 +1402,6 @@ data:
               - apiGroups:
                 - rbac.authorization.k8s.io
                 resources:
-                - clusterrole
-                - clusterrolebindings
                 - role
                 - rolebindings
                 - serviceaccounts
@@ -1420,6 +1432,21 @@ data:
                 - statefulsets
                 verbs:
                 - '*'
+
+            clusterPermissions:
+            - serviceAccountName: kubevirt-operator
+              rules:
+              - apiGroups:
+                - rbac.authorization.k8s.io
+                resources:
+                - clusterrole
+                - clusterrolebinding
+                verbs:
+                - get
+                - create
+                - delete
+                - patch
+                - update
 
             deployments:
             - name: kubevirt-operator


### PR DESCRIPTION
This will make it so the service account doesn't need cluster-admin.