### PR TITLE
Create a skeleton for handling more lifecycle operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
 FROM alpine:3.6
 
 RUN apk update && \
-    apk add curl
+    apk add curl git
 
 RUN wget -P /usr/bin http://storage.googleapis.com/kubernetes-release/release/v1.10.7/bin/linux/amd64/kubectl
 RUN chmod 755 /usr/bin/kubectl
 
-ARG VERSION=latest
-ENV VERSION=$VERSION
-RUN echo $VERSION
-
 RUN mkdir /etc/kubevirt
 COPY download-templates /bin
-RUN download-templates
+RUN download-templates /etc/kubevirt
 
 RUN adduser -D kubevirt-operator
 RUN chown -R kubevirt-operator: /etc/kubevirt

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ kubevirt-operator: $(GOLANG_FILES)
 ##############
 
 build: compile
-	docker build -t $(REPO):$(TAG) -f Dockerfile --build-arg VERSION=$(TAG) .
+	docker build -t $(REPO):$(TAG) -f Dockerfile .
 
 push:
 	docker push $(REPO):$(TAG)

--- a/download-templates
+++ b/download-templates
@@ -1,15 +1,22 @@
 #!/bin/sh
 
-set -e
-
-VERSION="${1:-$VERSION}"
-CONFIG_DIR="${2:-/etc/kubevirt}"
+CONFIG_DIR="${1:-/etc/kubevirt}"
 MANIFEST_URL="https://github.com/kubevirt/kubevirt/releases/download"
 
+echo "Downloading release templates from kubevirt/kubevirt"
 
-if [ "${VERSION}" == "latest" ]; then
-    VERSION=$(curl --silent "https://api.github.com/repos/kubevirt/kubevirt/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "${versions}" ]; then
+   versions=$(git ls-remote --tags https://github.com/kubevirt/kubevirt |  sed 's/.*refs\/tags\///g' | grep -v '\^{}')
 fi
 
-echo "Downloading ${VERSION} release templates from kubevirt/kubevirt"
-curl -Lf "${MANIFEST_URL}/${VERSION}/kubevirt.yaml" -o "${CONFIG_DIR}/kubevirt.yaml"
+for version in ${versions}; do
+    echo "Downloading template for ${version}"
+
+    if [ ! -d "${version}" ]; then
+    	mkdir "${CONFIG_DIR}/${version}"
+    fi
+
+    curl -Lf "${MANIFEST_URL}/${version}/kubevirt.yaml" -o "${CONFIG_DIR}/${version}/kubevirt.yaml"
+
+    echo "Download for ${version} complete"
+done

--- a/pkg/apis/virt/v1alpha1/types.go
+++ b/pkg/apis/virt/v1alpha1/types.go
@@ -22,7 +22,8 @@ type Virt struct {
 }
 
 type VirtSpec struct {
-	// Fill me
+	Version  string
+	Registry string
 }
 type VirtStatus struct {
 	// Fill me

--- a/pkg/kubevirt/reconcile.go
+++ b/pkg/kubevirt/reconcile.go
@@ -1,0 +1,105 @@
+package kubevirt
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/kubevirt/kubevirt-operator/pkg/apis/virt/v1alpha1"
+
+	"github.com/sirupsen/logrus"
+)
+
+type config struct {
+	version  string
+	registry string
+	manifest string
+}
+
+// Reconcile - Reconcile the current state of the world with the expected state
+func Reconcile(v *v1alpha1.Virt) error {
+	conf, err := newConfig(v)
+	if err != nil {
+		return err
+	}
+
+	err = renderConfigFile(conf)
+	if err != nil {
+		return err
+	}
+
+	applyManifest(conf)
+
+	return nil
+}
+
+func applyManifest(c config) {
+	// Create kubevirt manifest using the client
+	cmd := exec.Command("kubectl", "apply", "-f", c.manifest)
+	// Error is outputed in plain text in out
+	out, _ := cmd.CombinedOutput()
+	if strings.Contains(string(out), "Error from server (AlreadyExists)") {
+		logrus.Infof("KubeVirt resources already exist in the cluster")
+		logrus.Debugf(string(out))
+	} else {
+		logrus.Errorf("Applying KubeVirt %s manifest", c.version)
+		logrus.Infof(string(out))
+	}
+}
+
+// Until we have go templates for manifests, use string replace
+func renderConfigFile(c config) error {
+	in, err := ioutil.ReadFile(c.manifest)
+	if err != nil {
+		logrus.Errorf("KubeVirt Version %s is not supported by the operator", c.version)
+		return err
+	}
+
+	lines := strings.Split(string(in), "\n")
+	for l, line := range lines {
+		if strings.Contains(line, "docker.io") {
+			// Replace registry
+			r := strings.Replace(line, "docker.io", c.registry, -1)
+			lines[l] = r
+		}
+	}
+	o := strings.Join(lines, "\n")
+	err = ioutil.WriteFile(c.manifest, []byte(o), 0644)
+	if err != nil {
+		logrus.Errorf("Failed to render new config file")
+		return err
+	}
+
+	return nil
+}
+
+func newConfig(v *v1alpha1.Virt) (
+	config, error) {
+	kubevirtVersion := v.Spec.Version
+	registry := v.Spec.Registry
+	if kubevirtVersion == "" {
+		kubevirtVersion = LatestKubevirtVersion
+	}
+	if registry == "" {
+		registry = "docker.io"
+	}
+
+	manifest := fmt.Sprintf("/etc/kubevirt/%s/kubevirt.yaml", kubevirtVersion)
+
+	_, err := os.Stat(manifest)
+	if os.IsNotExist(err) {
+		logrus.Errorf("KubeVirt Version %s is not supported by the operator", kubevirtVersion)
+	}
+	if err != nil {
+		return config{}, errors.New("Unsupported KubeVirt Version")
+	}
+
+	return config{
+		version:  kubevirtVersion,
+		registry: registry,
+		manifest: manifest,
+	}, nil
+}

--- a/pkg/kubevirt/version.go
+++ b/pkg/kubevirt/version.go
@@ -1,0 +1,3 @@
+package kubevirt
+
+var LatestKubevirtVersion = "v0.9.0-alpha.0"

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -2,13 +2,11 @@ package stub
 
 import (
 	"context"
-	"os/exec"
-	"strings"
 
 	"github.com/kubevirt/kubevirt-operator/pkg/apis/virt/v1alpha1"
+	"github.com/kubevirt/kubevirt-operator/pkg/kubevirt"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
-	"github.com/sirupsen/logrus"
 )
 
 func NewHandler() sdk.Handler {
@@ -20,17 +18,9 @@ type Handler struct {
 }
 
 func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
-	switch event.Object.(type) {
+	switch o := event.Object.(type) {
 	case *v1alpha1.Virt:
-		// Create kubevirt manifest using the client
-		cmd := exec.Command("kubectl", "create", "-f", "/etc/kubevirt/kubevirt.yaml")
-		// Error is outputed in plain text in out
-		out, _ := cmd.CombinedOutput()
-		if strings.Contains(string(out), "Error from server (AlreadyExists)") {
-			logrus.Debugf("Resources from kubevirt.yaml already exist")
-		} else {
-			logrus.Infof(string(out))
-		}
+		return kubevirt.Reconcile(o)
 	}
 	return nil
 }


### PR DESCRIPTION
- Add the ability to set the kubevirt version
- Run a upgrade - spin up and spin down - of kubevirt
- Pull apart lifecycle operation logic so as to make it easier for new
  operations
- Independent tagging of the kubevirt operator