### PR TITLE
Change the namespace to openshift-operator-lifecycle-manager

### DIFF
--- a/kubevirt-catalog-source.yaml
+++ b/kubevirt-catalog-source.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: kubevirt-operator
-  namespace: operator-lifecycle-manager
+  namespace: openshift-operator-lifecycle-manager
 spec:
   sourceType: internal
   configMap: kubevirt-operator

--- a/kubevirt-operator-configmap.yaml
+++ b/kubevirt-operator-configmap.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: kubevirt-operator
-  namespace: operator-lifecycle-manager
+  namespace: openshift-operator-lifecycle-manager
 data:
   customResourceDefinitions: |-
     - apiVersion: apiextensions.k8s.io/v1beta1


### PR DESCRIPTION
Change the namespace since 'operator-lifecycle-manager'
does not get created during the olm setup,
while openshift-operator-lifecycle-manager namespace does.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>