### PR TITLE
Delete kubevirt when virt CR is deleted

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -20,7 +20,7 @@ type Handler struct {
 func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 	switch o := event.Object.(type) {
 	case *v1alpha1.Virt:
-		return kubevirt.Reconcile(o)
+		return kubevirt.Reconcile(o, event.Deleted)
 	}
 	return nil
 }


### PR DESCRIPTION
Deleting the kubevirt CR will cleanup kubevirt.