### PR TITLE
Add ember operator dependency

### DIFF
--- a/kubevirt-operator-configmap.yaml
+++ b/kubevirt-operator-configmap.yaml
@@ -1486,6 +1486,13 @@ data:
             displayName: virtualmachine
             description: Virtual Machines
 
+          required:
+          - name: embercsis.ember-csi.io
+            version: v1alpha1
+            kind: EmberCSI
+            displayName: EmberCSI Application
+            description: Represents an instance of a EmberCSI application
+
   packages: |-
     - packageName: kubevirt
       channels:


### PR DESCRIPTION
When creating a subscription for the KubeVirt operator via the OLM,
one must install first the Ember-CSI operator's catalog-source and
configmap and than create the subscription.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>