### PR TITLE
Add ember operator dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ push:
 
 olm:
 	oc create -f kubevirt-operator-configmap.yaml -f kubevirt-catalog-source.yaml
+	git clone -f https://github.com/kirankt/ember-csi-operator.git /tmp/ember-csi-operator
+	oc create -f /tmp/ember-csi-operator/deploy/olm-catalog/catalog-source.yml
+	oc create -f /tmp/ember-csi-operator/deploy/olm-catalog/configmap.yml
 
 rm-olm:
 	oc delete -f kubevirt-operator-configmap.yaml -f kubevirt-catalog-source.yaml

--- a/kubevirt-operator-configmap.yaml
+++ b/kubevirt-operator-configmap.yaml
@@ -1486,6 +1486,13 @@ data:
             displayName: virtualmachine
             description: Virtual Machines
 
+          required:
+          - name: embercsis.ember-csi.io
+            version: v1alpha1
+            kind: EmberCSI
+            displayName: EmberCSI Application
+            description: Represents an instance of a EmberCSI application
+
   packages: |-
     - packageName: kubevirt
       channels:


### PR DESCRIPTION
When creating a subscription for the KubeVirt operator via the OLM,
the Ember-CSI operator's catalog-source and configmap files
must be created first.

Depends on: https://github.com/kirankt/ember-csi-operator/pull/3

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>