### PR TITLE
Add cdi-operator as a dependency

### DIFF
--- a/kubevirt-operator-configmap.yaml
+++ b/kubevirt-operator-configmap.yaml
@@ -1493,6 +1493,12 @@ data:
             displayName: EmberCSI Application
             description: Represents an instance of a EmberCSI application
 
+          - name: cdis.cdi.kubevirt.io
+            version: v1alpha1
+            kind: CDI
+            displayName: CDI Application
+            description: Represents an instance of a CDI application
+
   packages: |-
     - packageName: kubevirt
       channels:


### PR DESCRIPTION
depends on: https://github.com/kubevirt/cdi-operator/pull/11

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>