### PR TITLE
Minor improvements and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 tmp/_output
 tmp/_test
 
+# Binaries
+kubevirt-operator
 
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ GOLANG_FILES:=$(shell find . -name \*.go -print)
 pkgs = $(shell go list ./... | grep -v /vendor/ )
 
 dep:
+	go get -u github.com/golang/dep/cmd/dep
 	dep ensure -v
-	wget -O kubevirt.yaml https://github.com/kubevirt/kubevirt/releases/download/v0.6.4/kubevirt.yaml
 
 all: format dep compile build deploy
 

--- a/pkg/kubevirt/version.go
+++ b/pkg/kubevirt/version.go
@@ -1,3 +1,3 @@
 package kubevirt
 
-var LatestKubevirtVersion = "v0.9.0-alpha.0"
+var LatestKubevirtVersion = "v0.9.6"


### PR DESCRIPTION
* ensure `dep` command
* no need to download kubevirt.yaml
* add kubevirt-operator binary to .gitignore
* update latest version of kubevirt